### PR TITLE
Fix for serialization of CustomField

### DIFF
--- a/src/Kralizek.Assembla.Connector/Connector/Tickets/CustomFields/CustomField.cs
+++ b/src/Kralizek.Assembla.Connector/Connector/Tickets/CustomFields/CustomField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Kralizek.Assembla.Connector.Spaces;
 using Newtonsoft.Json;
 
 namespace Kralizek.Assembla.Connector.Tickets.CustomFields
@@ -30,6 +31,7 @@ namespace Kralizek.Assembla.Connector.Tickets.CustomFields
         public string DefaultValue { get; set; }
 
         [JsonProperty("list_options")]
+        [JsonConverter(typeof(TabListJsonConverter))]
         public string[] ListOptions { get; set; }
 
         [JsonProperty("created_at")]

--- a/src/Kralizek.Assembla.Connector/Kralizek.Assembla.Connector.csproj
+++ b/src/Kralizek.Assembla.Connector/Kralizek.Assembla.Connector.csproj
@@ -8,7 +8,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <PackageProjectUrl>https://github.com/Kralizek/Assembla.Connector</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Kralizek/Assembla.Connector/master/LICENSE</PackageLicenseUrl>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <PackageTags>assembla;dotnet-core;dotnet-standard;rest-api;netstandard</PackageTags>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Added missing TabListJsonConverter for ListOptions on CustomField since it needs to be a comma separated list when writing, but is an array when reading according to api documentation